### PR TITLE
update duisburg.json

### DIFF
--- a/duisburg.json
+++ b/duisburg.json
@@ -40,6 +40,11 @@
     }
   ],
   "nodeMaps": [
+    { "url": "http://map.rg-west.freifunk.ruhr/",
+      "interval": "5m",
+      "technicalType": "meshviewer",
+      "mapType": "list/status"
+    },
     {
       "url": "http://map.freifunk-ruhrgebiet.de/graph.html",
       "interval": "1 Minute",


### PR DESCRIPTION
add map.rg-west.freifunk.ruhr/ as meshviewer source 
which also affect oberhausen and mühlheim ruhr 
so freifunk-karte.de could parse correct map data and gps coord. 
leaving the maybe false // outdated links of map.freifunk-ruhrgebiet.de intact,
this should be "repaired" by somebody from Duisburg community itself (with other outdated data)
